### PR TITLE
Fix SVG fill attribute bug

### DIFF
--- a/image_occlusion_2/svgutils.py
+++ b/image_occlusion_2/svgutils.py
@@ -89,9 +89,7 @@ def nr_of_shapes(svg):
 
 
 def set_color(elt, color):
-    style = parseStyle(elt.get('style'))
-    style.update({'fill': color, 'fill-opacity': '1'})
-    elt.set('style', formatStyle(style))
+    elt.attrib["fill"] = "#" + color
 
 
 #  Applies the change of color to the children of the


### PR DESCRIPTION
Image Occlusion has been writing SVG tags incorrectly. The "question" shape is supposed to be colored red but instead of setting the fill attribute, this color was being written into a separate style attribute. This is rendered appropriately with desktop Anki, but the Android 5.1 release no longer displays the tag correctly and the result of this is shown in the attached screenshots. This update fixes the fill attribute tag so any Image Occlusion cards created will be displayed correctly on Android.
![desktop](https://cloud.githubusercontent.com/assets/905222/6839374/6f118ae2-d335-11e4-9ff2-51abcbafb78e.png)
![ankidroid](https://cloud.githubusercontent.com/assets/905222/6839377/73ba05f6-d335-11e4-88ec-ce18ed064f7e.png)
